### PR TITLE
chore: bump spring-boot parent to 4.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.7</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
# Summary

- Bump spring-boot-starter-parent from 4.0.3 to 4.0.7
- Resolves all 25 Dependabot alerts: Netty 4.2.10 → 4.2.15.Final, Jackson 3.0.4 → 3.1.4, Jackson 2.20.2 → 2.21.4, Spring Boot actuator auth bypass CVEs